### PR TITLE
interfaces内テストの修正

### DIFF
--- a/src/app/interfaces/database/album_repository_test.go
+++ b/src/app/interfaces/database/album_repository_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"domain"
 	"interfaces/database/rdb"
+	"sort"
 	"test/infrastructure"
 	"testing"
 	"time"
@@ -62,6 +63,23 @@ func (suite *GetAlbumTestSuite) TearDownTest() {
 	}
 }
 
+func assertCredits(t *testing.T, expected []domain.Credit, got []domain.Credit) {
+	assert.Equal(t, len(expected), len(got))
+	// sort expected and got by ArtistID
+	sort.Slice(expected, func(i, j int) bool {
+		p, q := got[i], got[j]
+		return p.Artist.ID < q.Artist.ID
+	})
+	sort.Slice(got, func(i, j int) bool {
+		p, q := got[i], got[j]
+		return p.Artist.ID < q.Artist.ID
+	})
+	for i := range expected {
+		assert.Equal(t, expected[i].Artist, got[i].Artist)
+		assert.ElementsMatch(t, expected[i].Parts, got[i].Parts)
+	}
+}
+
 func (suite *GetAlbumTestSuite) TestGetAlbum() {
 	testURL := "http://www.example.com"
 	testDate, _ := time.Parse("2006-01-02", "2021-01-13")
@@ -94,7 +112,7 @@ func (suite *GetAlbumTestSuite) TestGetAlbum() {
 	assert.Equal(suite.T(), expectedAlbum.ID, album.ID)
 	assert.Equal(suite.T(), expectedAlbum.Name, album.Name)
 	assert.Equal(suite.T(), expectedAlbum.PrimaryArtist, album.PrimaryArtist)
-	assert.ElementsMatch(suite.T(), expectedAlbum.Credits, album.Credits)
+	assertCredits(suite.T(), expectedAlbum.Credits, album.Credits)
 	assert.Equal(suite.T(), expectedAlbum.Label, album.Label)
 	assert.Equal(suite.T(), expectedAlbum.ReleasedDate, album.ReleasedDate)
 	assert.Equal(suite.T(), expectedAlbum.ImageURL, album.ImageURL)

--- a/src/app/interfaces/database/album_repository_test.go
+++ b/src/app/interfaces/database/album_repository_test.go
@@ -5,6 +5,7 @@ import (
 	"interfaces/database/rdb"
 	"sort"
 	"test/infrastructure"
+	"test/interfaces"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ func assertCredits(t *testing.T, expected []domain.Credit, got []domain.Credit) 
 	assert.Equal(t, len(expected), len(got))
 	// sort expected and got by ArtistID
 	sort.Slice(expected, func(i, j int) bool {
-		p, q := got[i], got[j]
+		p, q := expected[i], expected[j]
 		return p.Artist.ID < q.Artist.ID
 	})
 	sort.Slice(got, func(i, j int) bool {
@@ -112,7 +113,7 @@ func (suite *GetAlbumTestSuite) TestGetAlbum() {
 	assert.Equal(suite.T(), expectedAlbum.ID, album.ID)
 	assert.Equal(suite.T(), expectedAlbum.Name, album.Name)
 	assert.Equal(suite.T(), expectedAlbum.PrimaryArtist, album.PrimaryArtist)
-	assertCredits(suite.T(), expectedAlbum.Credits, album.Credits)
+	interfaces.AssertCredits(suite.T(), expectedAlbum.Credits, album.Credits)
 	assert.Equal(suite.T(), expectedAlbum.Label, album.Label)
 	assert.Equal(suite.T(), expectedAlbum.ReleasedDate, album.ReleasedDate)
 	assert.Equal(suite.T(), expectedAlbum.ImageURL, album.ImageURL)

--- a/src/app/interfaces/database/artist_repository_test.go
+++ b/src/app/interfaces/database/artist_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"domain"
 	"interfaces/database/rdb"
 	"test/infrastructure"
+	"test/interfaces"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,7 +105,12 @@ func (suite *GetArtistTestSuite) TestGetArtist() {
 	if err != nil {
 		panic(err)
 	}
-	assert.Equal(suite.T(), expectedArtist, artist)
+	assert.Equal(suite.T(), expectedArtist.ID, artist.ID)
+	assert.Equal(suite.T(), expectedArtist.Name, artist.Name)
+	assert.Equal(suite.T(), expectedArtist.ImageURL, artist.ImageURL)
+	assert.Equal(suite.T(), expectedArtist.Description, artist.Description)
+	assert.Equal(suite.T(), expectedArtist.Links, artist.Links)
+	assert.ElementsMatch(suite.T(), expectedArtist.Parts, artist.Parts)
 }
 
 func (suite *GetArtistTestSuite) TestGetArtistAlias() {
@@ -160,7 +166,7 @@ func (suite *GetArtistTestSuite) TestGetArtistGroup() {
 	}
 	assert.Equal(suite.T(), expectedArtist.ID, artist.ID)
 	assert.Equal(suite.T(), expectedArtist.Name, artist.Name)
-	assert.ElementsMatch(suite.T(), expectedArtist.Members, artist.Members)
+	interfaces.AssertCredits(suite.T(), expectedArtist.Members.([]domain.Credit), artist.Members.([]domain.Credit))
 	assert.Equal(suite.T(), expectedArtist.Description, artist.Description)
 	assert.Equal(suite.T(), expectedArtist.ImageURL, artist.ImageURL)
 }

--- a/src/app/interfaces/database/song_repository_test.go
+++ b/src/app/interfaces/database/song_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"domain"
 	"interfaces/database/rdb"
 	"test/infrastructure"
+	"test/interfaces"
 	"testing"
 	"time"
 
@@ -125,7 +126,7 @@ func (suite *GetSongTestSuite) TestGetSong() {
 	assert.Equal(suite.T(), expectedSong.ID, song.ID)
 	assert.Equal(suite.T(), expectedSong.Name, song.Name)
 	assert.Equal(suite.T(), expectedSong.PrimaryArtist, song.PrimaryArtist)
-	assert.ElementsMatch(suite.T(), expectedSong.Credits, song.Credits)
+	interfaces.AssertCredits(suite.T(), expectedSong.Credits, song.Credits)
 	assert.Equal(suite.T(), expectedSong.Album, song.Album)
 	assert.Equal(suite.T(), expectedSong.SongLen, song.SongLen)
 	assert.Equal(suite.T(), expectedSong.Genre, song.Genre)

--- a/src/app/test/interfaces/Tools.go
+++ b/src/app/test/interfaces/Tools.go
@@ -1,0 +1,26 @@
+package interfaces
+
+import (
+	"domain"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertCredits(t *testing.T, expected []domain.Credit, got []domain.Credit) {
+	assert.Equal(t, len(expected), len(got))
+	// sort expected and got by ArtistID
+	sort.Slice(expected, func(i, j int) bool {
+		p, q := expected[i], expected[j]
+		return p.Artist.ID < q.Artist.ID
+	})
+	sort.Slice(got, func(i, j int) bool {
+		p, q := got[i], got[j]
+		return p.Artist.ID < q.Artist.ID
+	})
+	for i := range expected {
+		assert.Equal(t, expected[i].Artist, got[i].Artist)
+		assert.ElementsMatch(t, expected[i].Parts, got[i].Parts)
+	}
+}


### PR DESCRIPTION
現状
- Credits（[]Credit型）のアサーションにassert.ElementsMatchを使っていた。

問題点
- ElementsMatchは配列を比較して、要素の順序は問わず同じ要素が含まれるかチェックするアサーション関数。Credits自体の順序は無視するがCredit.Partsの順序は考慮されてしまうため、テストが落ちることがあった。

改善策
- AssertCredits関数を実装。この関数はまずCreditsをArtistIDでソーティング。その後各Creditに対して、ArtistとPartsそれぞれチェックする。