### PR TITLE
delete logger, jwt-go

### DIFF
--- a/src/app/infrastructure/go.mod
+++ b/src/app/infrastructure/go.mod
@@ -3,7 +3,6 @@ module github.com/aapaca/aapaca_backend/src/app/infrastructure
 go 1.14
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/labstack/echo v3.3.10+incompatible

--- a/src/app/infrastructure/router.go
+++ b/src/app/infrastructure/router.go
@@ -4,7 +4,6 @@ import (
 	"interfaces/controller"
 
 	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
 )
 
 func Init() {
@@ -23,8 +22,5 @@ func Init() {
 	artistController := controller.NewArtistController(sqlHandler)
 	e.GET("/artists/:id", artistController.GetArtist())
 
-	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: "${time_rfc3339} method=${method}, uri=${uri}, status=${status}\n",
-	}))
 	e.Logger.Fatal(e.Start(":1323"))
 }


### PR DESCRIPTION
変更内容
- logger削除（cloud runがすでにログを吐いてくれていた）
- jwt-go packageを削除（脆弱性対策）